### PR TITLE
[Asana] Fix autocomplete on tab

### DIFF
--- a/lib/init.js
+++ b/lib/init.js
@@ -2024,8 +2024,9 @@ JanewayClass.setMethod(function start(options, callback) {
 					selectAutocomplete(true);
 				}
 
-				cli.setValue(cmd, true);
-				this.autocomplete(cmd, key);
+				setImmediate(function() {
+					cli.setValue(cli.getValue().replace(/\t$/, ''), true);
+				});
 				return;
 			}
 


### PR DESCRIPTION
This is an interesting issue:
`this.autocomplete(cmd, key)` causes undefined error since `this` does not exist in the closure. And the error hides the real issue that `tab` key is appended to the end of input. The fix is to render the input in the next render cycle with `tab` characters stripped. 
Also `autocomplete()` is not really needed here. 