### PR TITLE
[Asana] Remove copy-paste due to vulnerability

### DIFF
--- a/lib/init.js
+++ b/lib/init.js
@@ -7,7 +7,6 @@ if (typeof __Janeway !== 'undefined') {
 var blessed = require('neo-blessed'),
     Blast = require('protoblast')(false), // Protoblast without native mods
     util  = require('util'),
-    ncp   = require('copy-paste'),
     vm    = require('vm'),
     os    = require('os'),
     fs    = require('fs'),
@@ -268,8 +267,7 @@ JanewayClass.setProperty('default_config', {
 	},
 	copy_json: {
 		enabled : true,
-		title   : 'Copy JSON',
-		try_clipboard: true,
+		title   : 'Dump JSON',
 		dump_to_file : true,
 	},
 	menu: {
@@ -2231,14 +2229,6 @@ JanewayClass.setMethod(function _createMenu() {
 
 		if (!json) {
 			return;
-		}
-
-		if (that.config.copy_json.try_clipboard) {
-			ncp.copy(json, function copied(err) {
-				if (err) {
-					that.printError('Failed to copy to clipboard');
-				}
-			});
 		}
 
 		if (that.config.copy_json.dump_to_file) {

--- a/package.json
+++ b/package.json
@@ -22,7 +22,6 @@
 	"license": "MIT",
 	"dependencies": {
 		"neo-blessed"  : "~0.2.0",
-		"copy-paste"   : "~1.3.0",
 		"isbinaryfile" : "~3.0.3",
 		"protoblast"   : "~0.7.1"
 	},


### PR DESCRIPTION
Issue: https://github.com/advisories/GHSA-38h8-x697-gh8q

sync-exec is a sub-dependency. Here's how we depend on vulnerable versions of sync-exec:
janeway -> copy-paste -> sync-exec (v0.6.2)

https://app.asana.com/0/1201223855489374/1202133359647043/f