### PR TITLE
Fix getLocale error in date format

### DIFF
--- a/lib/class/args_log_line.js
+++ b/lib/class/args_log_line.js
@@ -9,6 +9,10 @@ module.exports = function defineLogLine(Janeway, Blast, Bound) {
 	    S = Bound.String,
 	    KEY = Symbol('key');
 
+	var formatDate = function(date) {
+		return date.toISOString().substr(0, 19); //remove ending ".000Z"
+	};
+
 	/**
 	 * A generic line of text in the log list output
 	 *
@@ -187,8 +191,8 @@ module.exports = function defineLogLine(Janeway, Blast, Bound) {
 		} else {
 			result = '{';
 
-			if (arg.constructor.name == 'Date' && arg.getUTCDate) {
-				result += Blast.Bound.Date.format(arg, this.janeway.config.properties.date_format);
+			if (arg.constructor.name == 'Date') {
+				result += formatDate(arg);
 				result += '}';
 				return result;
 			}
@@ -374,8 +378,8 @@ module.exports = function defineLogLine(Janeway, Blast, Bound) {
 
 						str = esc(1, '{', 21) + esc('1;93', temp, '39') + ' ';
 
-						if (arg.constructor.name == 'Date' && arg.getUTCDate) {
-							str += Blast.Bound.Date.format(arg, this.janeway.config.properties.date_format);
+						if (arg.constructor.name == 'Date') {
+							str += formatDate(arg);
 						} else {
 							str += len;
 						}


### PR DESCRIPTION
Fix `getLocale` error with `new Date(...)`:
- there's a bug in `date_format.js`, which calls `this.getLocale` when it is undefined as a result of [not having native mods](https://github.com/Asana/janeway/blob/master/lib/init.js#L8).  See stack trace. 
- since native `Date` does not support custom format and we probably never need it in js2, I simply replaced it with `toISOString` 

Stack trace:
```
00 TypeError: this.getLocale is not a function                                                                                                                                                                              
         01     at Date.getDayName (/Users/frankliu/ExcludeFromBackup/workspace/janeway/node_modules/protoblast/lib/date_format.js:195:16)                                                                                           
         02     at /Users/frankliu/ExcludeFromBackup/workspace/janeway/node_modules/protoblast/lib/date_format.js:143:54                                                                                                             
         03     at String.replace (<anonymous>)                                                                                                                                                                                      
         04     at Date.format (/Users/frankliu/ExcludeFromBackup/workspace/janeway/node_modules/protoblast/lib/date_format.js:142:17)                                                                                               
         05     at Object.format (eval at unmethodize (/Users/frankliu/ExcludeFromBackup/workspace/janeway/node_modules/protoblast/lib/function.js:628:2), <anonymous>:10:15)                                                        
         06     at EvalOutputLogLine.dissect (/Users/frankliu/ExcludeFromBackup/workspace/janeway/lib/class/args_log_line.js:378:32) 
```
